### PR TITLE
Add the ability to subscript SQLRow by column name

### DIFF
--- a/Sources/SwiftSQL/SQLStatement.swift
+++ b/Sources/SwiftSQL/SQLStatement.swift
@@ -242,6 +242,21 @@ public final class SQLStatement {
     public func columnName(at index: Int) -> String {
         String(cString: sqlite3_column_name(ref, Int32(index)))
     }
+    
+    // MARK: Indices from Names
+    
+    /// Returns the index of a column given its name.
+    public func columnIndex(forName name: String) -> Int? {
+        return columnIndices[name]
+    }
+    private lazy var columnIndices: [String : Int] = {
+        var indices: [String : Int] = [:]
+        indices.reserveCapacity(columnCount)
+        for index in 0..<columnCount {
+            indices[String(cString: sqlite3_column_name(ref, Int32(index)))] = index
+        }
+        return indices
+    }()
 
     // MARK: Reset
 

--- a/Sources/SwiftSQLExt/SwiftSQLExt.swift
+++ b/Sources/SwiftSQLExt/SwiftSQLExt.swift
@@ -20,6 +20,9 @@ public extension SQLStatement {
     func rows<T: SQLRowDecodable>(_ type: T.Type, count: Int? = nil) throws -> [T] {
         var objects = [T]()
         let limit = count ?? Int.max
+        if let count = count {
+            objects.reserveCapacity(count)
+        }
         while let object = try row(T.self), objects.count < limit {
             objects.append(object)
         }
@@ -59,6 +62,32 @@ public struct SQLRow {
     /// - parameter index: The leftmost column of the result set has the index 0.
     public subscript<T: SQLDataType>(index: Int) -> T? {
         statement.column(at: index)
+    }
+    
+    /// Returns a single column (by its name) of the current result row of a query.
+    ///
+    /// If the SQL statement does not currently point to a valid row, the result is undefined.
+    /// If the passed columnName doesn't point to a valid column name, a fatal error is raised.
+    ///
+    /// - parameter columnName: The name of the column.
+    public subscript<T: SQLDataType>(columnName: String) -> T {
+        guard let columnIndex = statement.columnIndex(forName: columnName) else {
+            fatalError("No such column \(columnName)")
+        }
+        return statement.column(at: columnIndex)
+    }
+    
+    /// Returns a single column (by its name) of the current result row of a query.
+    ///
+    /// If the SQL statement does not currently point to a valid row, the result is undefined.
+    /// If the passed columnName doesn't point to a valid column name, nil is returned.
+    ///
+    /// - parameter columnName: The name of the column.
+    public subscript<T: SQLDataType>(columnName: String) -> T? {
+        guard let columnIndex = statement.columnIndex(forName: columnName) else {
+            return nil
+        }
+        return statement.column(at: columnIndex)
     }
 }
 


### PR DESCRIPTION
This PR adds the ability to subscript `SQLRow` by column name to be able to write something like this for `SQLRowDecodable` types:

```swift
init(row: SQLRow) throws {
    self.name = row["Name"]
    self.level = row["Level"]
}
```

There are two subscript versions; one that returns a value of the inferred type `T`, and one that returns an optional value `T?`. The first one **crashes** if the result has no such column, while the second version returns `nil`.

I've also added the needed unit tests. However, there's a code path I couldn't write test for unless we introduce a custom fatal error utility that is test-friendly. So, I thought first to see if you can accept such change in the first place, and if so, maybe you have a better idea for testing the fatal error code path.

Thanks!