### PR TITLE
Int type tolerance, and better SQLDataType conversion requirements and conveniences

### DIFF
--- a/Sources/SwiftSQL/SQLDataType.swift
+++ b/Sources/SwiftSQL/SQLDataType.swift
@@ -12,6 +12,7 @@ import SQLite3
 public protocol SQLDataType {
     func sqlBind(statement: OpaquePointer, index: Int32)
     static func sqlColumn(statement: OpaquePointer, index: Int32) -> Self
+    static func convert(from value: Any) -> Self?
 }
 
 public extension SQLDataType {
@@ -25,6 +26,11 @@ extension Int: SQLDataType {
 
     public static func sqlColumn(statement: OpaquePointer, index: Int32) -> Int {
         Int(sqlite3_column_int64(statement, index))
+    }
+    
+    public static func convert(from value: Any) -> Int? {
+        guard let int64 = value as? Int64 else { return nil }
+        return Int(int64)
     }
 }
 

--- a/Sources/SwiftSQL/SQLDataType.swift
+++ b/Sources/SwiftSQL/SQLDataType.swift
@@ -15,10 +15,6 @@ public protocol SQLDataType {
     static func convert(from value: Any) -> Self?
 }
 
-public extension SQLDataType {
-    static func convert(from value: Any) -> Self? { value as? Self }
-}
-
 extension Int: SQLDataType {
     public func sqlBind(statement: OpaquePointer, index: Int32) {
         sqlite3_bind_int64(statement, index, Int64(self))
@@ -42,6 +38,11 @@ extension Int32: SQLDataType {
     public static func sqlColumn(statement: OpaquePointer, index: Int32) -> Int32 {
         sqlite3_column_int(statement, index)
     }
+    
+    public static func convert(from value: Any) -> Self? {
+        guard let int64 = value as? Int64 else { return nil }
+        return Int32(int64)
+    }
 }
 
 extension Int64: SQLDataType {
@@ -52,6 +53,8 @@ extension Int64: SQLDataType {
     public static func sqlColumn(statement: OpaquePointer, index: Int32) -> Int64 {
         sqlite3_column_int64(statement, index)
     }
+    
+    public static func convert(from value: Any) -> Self? { value as? Self }
 }
 
 extension Double: SQLDataType {
@@ -62,6 +65,8 @@ extension Double: SQLDataType {
     public static func sqlColumn(statement: OpaquePointer, index: Int32) -> Double {
         sqlite3_column_double(statement, index)
     }
+    
+    public static func convert(from value: Any) -> Self? { value as? Self }
 }
 
 extension String: SQLDataType {
@@ -73,6 +78,8 @@ extension String: SQLDataType {
         guard let pointer = sqlite3_column_text(statement, index) else { return "" }
         return String(cString: pointer)
     }
+    
+    public static func convert(from value: Any) -> Self? { value as? Self }
 }
 
 extension Data: SQLDataType {
@@ -87,6 +94,8 @@ extension Data: SQLDataType {
         let count = Int(sqlite3_column_bytes(statement, Int32(index)))
         return Data(bytes: pointer, count: count)
     }
+    
+    public static func convert(from value: Any) -> Self? { value as? Self }
 }
 
 private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/Sources/SwiftSQLExt/SwiftSQLExt.swift
+++ b/Sources/SwiftSQLExt/SwiftSQLExt.swift
@@ -71,7 +71,11 @@ public struct SQLRow {
     ///
     /// - parameter index: The leftmost column of the result set has the index 0.
     public subscript<T: SQLDataType>(index: Int) -> T {
-        T.convert(from: values[index]!)!
+        let value = values[index]!
+        guard let convertedValue = T.convert(from: value) else {
+            fatalError("Could not convert \(type(of: value)). Make sure target type (\(T.self)) correctly implements convert(from:).")
+        }
+        return convertedValue
     }
 
     /// Returns a single column of the current result row of a query. If the

--- a/Tests/SwiftSQLExtTests/SwiftSQLExtTests.swift
+++ b/Tests/SwiftSQLExtTests/SwiftSQLExtTests.swift
@@ -170,9 +170,9 @@ private extension SQLConnection {
 
 private struct User: Hashable, SQLRowDecodable {
     let name: String
-    let level: Int64
+    let level: Int
 
-    init(name: String, level: Int64) {
+    init(name: String, level: Int) {
         self.name = name
         self.level = level
     }

--- a/Tests/SwiftSQLExtTests/SwiftSQLExtTests.swift
+++ b/Tests/SwiftSQLExtTests/SwiftSQLExtTests.swift
@@ -141,13 +141,13 @@ private extension SQLConnection {
         """)
 
         try insertUsersStatement
-            .bind("Alice", Int64(80))
+            .bind("Alice", 80)
             .execute()
 
         try insertUsersStatement.reset()
 
         try insertUsersStatement
-            .bind("Bob", Int64(90))
+            .bind("Bob", 90)
             .execute()
         
         let insertPersonsStatement = try self.prepare("""


### PR DESCRIPTION
While using the library, my code crashed on reading an `Int` property of a custom type conforming to `SQLDataType`. This happened because `SQLDataType` has a default implementation for `convert(from:)` that just casts to the target type, which is correct if the target type is `Int64` but not `Int`. 
https://github.com/kean/SwiftSQL/blob/81b97d9423574c031957a22679c5271d69b2d72e/Sources/SwiftSQL/SQLDataType.swift#L18

So:
1. I added correct conversion convenience for `Int` (i.e. `Int(int64)` where `int64` is the `Int64` value read upfront for each integer column).
2. I removed the problematic default `convert(from:)` implementation, and moved it to the protocol declaration as an explicit requirement. That way, if a user want a type to conform to `SQLDataType`, it's the user's responsibility to provide a correct conversion implementation. This brings up the `SQLVariant` argument again; should we tell the user explicitly what type are they going to convert from?
3. I added `convert(from:)` implementations for the types `Int`, `Int32`, `Int64`, `Double`, `String`, and `Data`.

I used `Int` for the `User` type in tests, and all passed.