### PR TITLE
Introduce SQLColumnValue and InitializableBySQLColumnValue

### DIFF
--- a/Sources/SwiftSQL/SQLColumnValue.swift
+++ b/Sources/SwiftSQL/SQLColumnValue.swift
@@ -1,0 +1,13 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+
+public enum SQLColumnValue {
+    case int64(Int64)
+    case double(Double)
+    case string(String)
+    case data(Data)
+    case null
+}

--- a/Sources/SwiftSQL/SQLDataType.swift
+++ b/Sources/SwiftSQL/SQLDataType.swift
@@ -12,7 +12,6 @@ import SQLite3
 public protocol SQLDataType {
     func sqlBind(statement: OpaquePointer, index: Int32)
     static func sqlColumn(statement: OpaquePointer, index: Int32) -> Self
-    static func convert(from value: Any) -> Self?
 }
 
 extension Int: SQLDataType {
@@ -22,11 +21,6 @@ extension Int: SQLDataType {
 
     public static func sqlColumn(statement: OpaquePointer, index: Int32) -> Int {
         Int(sqlite3_column_int64(statement, index))
-    }
-    
-    public static func convert(from value: Any) -> Int? {
-        guard let int64 = value as? Int64 else { return nil }
-        return Int(int64)
     }
 }
 
@@ -38,11 +32,6 @@ extension Int32: SQLDataType {
     public static func sqlColumn(statement: OpaquePointer, index: Int32) -> Int32 {
         sqlite3_column_int(statement, index)
     }
-    
-    public static func convert(from value: Any) -> Self? {
-        guard let int64 = value as? Int64 else { return nil }
-        return Int32(int64)
-    }
 }
 
 extension Int64: SQLDataType {
@@ -53,8 +42,6 @@ extension Int64: SQLDataType {
     public static func sqlColumn(statement: OpaquePointer, index: Int32) -> Int64 {
         sqlite3_column_int64(statement, index)
     }
-    
-    public static func convert(from value: Any) -> Self? { value as? Self }
 }
 
 extension Double: SQLDataType {
@@ -65,8 +52,6 @@ extension Double: SQLDataType {
     public static func sqlColumn(statement: OpaquePointer, index: Int32) -> Double {
         sqlite3_column_double(statement, index)
     }
-    
-    public static func convert(from value: Any) -> Self? { value as? Self }
 }
 
 extension String: SQLDataType {
@@ -78,8 +63,6 @@ extension String: SQLDataType {
         guard let pointer = sqlite3_column_text(statement, index) else { return "" }
         return String(cString: pointer)
     }
-    
-    public static func convert(from value: Any) -> Self? { value as? Self }
 }
 
 extension Data: SQLDataType {
@@ -94,8 +77,6 @@ extension Data: SQLDataType {
         let count = Int(sqlite3_column_bytes(statement, Int32(index)))
         return Data(bytes: pointer, count: count)
     }
-    
-    public static func convert(from value: Any) -> Self? { value as? Self }
 }
 
 private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)

--- a/Sources/SwiftSQL/SQLStatement.swift
+++ b/Sources/SwiftSQL/SQLStatement.swift
@@ -224,25 +224,25 @@ public final class SQLStatement {
         }
     }
     
-    public func column(at index: Int) -> Any? {
+    public func column(at index: Int) -> SQLColumnValue {
         let index = Int32(index)
         let type = sqlite3_column_type(ref, index)
         switch type {
             case SQLITE_INTEGER:
-                return sqlite3_column_int64(ref, index)
+                return .int64(sqlite3_column_int64(ref, index))
             case SQLITE_FLOAT:
-                return sqlite3_column_double(ref, index)
+                return .double(sqlite3_column_double(ref, index))
             case SQLITE_TEXT:
-                return String(cString: sqlite3_column_text(ref, index))
+                return .string(String(cString: sqlite3_column_text(ref, index)))
             case SQLITE_BLOB:
                 if let bytes = sqlite3_column_blob(ref, index) {
                     let byteCount = sqlite3_column_bytes(ref, index)
-                    return Data(bytes: bytes, count: Int(byteCount))
+                    return .data(Data(bytes: bytes, count: Int(byteCount)))
                 } else {
-                    return Data()
+                    return .data(Data())
                 }
             default:
-                return nil
+                return .null
         }
     }
 

--- a/Sources/SwiftSQLExt/InitializableBySQLColumnValue+ConvenienceConformances.swift
+++ b/Sources/SwiftSQLExt/InitializableBySQLColumnValue+ConvenienceConformances.swift
@@ -1,0 +1,116 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+import SwiftSQL
+
+// Conveniences for commonly used types.
+// Note that automatc type conversion is being done;
+// this is to maintain the expected type flexibility
+// of SQLite.
+// From the docs:
+// >If the result column is not initially in the requested format (for example, if the query returns an integer but the sqlite3_column_text() interface is used to extract the value) then an automatic type conversion is performed.
+// Reference: https://www.sqlite.org/c3ref/column_blob.html
+
+extension Int: InitializableBySQLColumnValue {
+    public init?(sqlColumnValue: SQLColumnValue) {
+        switch sqlColumnValue {
+            case .int64(let int64):
+                self = Int(int64)
+            case .double(let double):
+                self = Int(double)
+            case .string(let string):
+                if let int = Int(string) {
+                    self = int
+                } else {
+                    return nil
+                }
+            default:
+                return nil
+        }
+    }
+}
+
+extension Int32: InitializableBySQLColumnValue {
+    public init?(sqlColumnValue: SQLColumnValue) {
+        switch sqlColumnValue {
+            case .int64(let int64):
+                self = Int32(int64)
+            case .double(let double):
+                self = Int32(double)
+            case .string(let string):
+                if let int32 = Int32(string) {
+                    self = int32
+                } else {
+                    return nil
+                }
+            default:
+                return nil
+        }
+    }
+}
+
+extension Int64: InitializableBySQLColumnValue {
+    public init?(sqlColumnValue: SQLColumnValue) {
+        switch sqlColumnValue {
+            case .int64(let int64):
+                self = int64
+            case .double(let double):
+                self = Int64(double)
+            case .string(let string):
+                if let int64 = Int64(string) {
+                    self = int64
+                } else {
+                    return nil
+                }
+            default:
+                return nil
+        }
+    }
+}
+
+extension Double: InitializableBySQLColumnValue {
+    public init?(sqlColumnValue: SQLColumnValue) {
+        switch sqlColumnValue {
+            case .int64(let int64):
+                self = Double(int64)
+            case .double(let double):
+                self = double
+            case .string(let string):
+                if let double = Double(string) {
+                    self = double
+                } else {
+                    return nil
+                }
+            default:
+                return nil
+        }
+    }
+}
+
+extension String: InitializableBySQLColumnValue {
+    public init?(sqlColumnValue: SQLColumnValue) {
+        switch sqlColumnValue {
+            case .int64(let int64):
+                self = String(int64)
+            case .double(let double):
+                self = String(double)
+            case .string(let string):
+                self = string
+            default:
+                return nil
+        }
+    }
+}
+
+extension Data: InitializableBySQLColumnValue {
+    public init?(sqlColumnValue: SQLColumnValue) {
+        switch sqlColumnValue {
+            case .data(let data):
+                self = data
+            default:
+                return nil
+        }
+    }
+}

--- a/Tests/SwiftSQLExtTests/SwiftSQLExtTests.swift
+++ b/Tests/SwiftSQLExtTests/SwiftSQLExtTests.swift
@@ -113,7 +113,56 @@ final class SwiftSQLExtTests: XCTestCase {
         XCTAssertNil(try XCTUnwrap(row)["Level"] as Int?)
     }
     
+    func testInitializableBySQLColumnValueConveniencesIn64Source() throws {
+        // GIVEN
+        let sqlColumnValue = SQLColumnValue.int64(1)
+        
+        // WHEN
+        let int32 = Int32(sqlColumnValue: sqlColumnValue)
+        let int64 = Int64(sqlColumnValue: sqlColumnValue)
+        let double = Double(sqlColumnValue: sqlColumnValue)
+        let string = String(sqlColumnValue: sqlColumnValue)
+        
+        //THEN
+        XCTAssertEqual(try XCTUnwrap(int32), 1)
+        XCTAssertEqual(try XCTUnwrap(int64), 1)
+        XCTAssertEqual(try XCTUnwrap(double), 1)
+        XCTAssertEqual(try XCTUnwrap(string), "1")
+    }
     
+    func testInitializableBySQLColumnValueConveniencesDoubleSource() throws {
+        // GIVEN
+        let sqlColumnValue = SQLColumnValue.double(1)
+        
+        // WHEN
+        let int = Int(sqlColumnValue: sqlColumnValue)
+        let int32 = Int32(sqlColumnValue: sqlColumnValue)
+        let int64 = Int64(sqlColumnValue: sqlColumnValue)
+        let string = String(sqlColumnValue: sqlColumnValue)
+        
+        //THEN
+        XCTAssertEqual(try XCTUnwrap(int), 1)
+        XCTAssertEqual(try XCTUnwrap(int32), 1)
+        XCTAssertEqual(try XCTUnwrap(int64), 1)
+        XCTAssertEqual(try XCTUnwrap(string), "1.0")
+    }
+    
+    func testInitializableBySQLColumnValueConveniencesStringSource() throws {
+        // GIVEN
+        let sqlColumnValue = SQLColumnValue.string("1")
+        
+        // WHEN
+        let int = Int(sqlColumnValue: sqlColumnValue)
+        let int32 = Int32(sqlColumnValue: sqlColumnValue)
+        let int64 = Int64(sqlColumnValue: sqlColumnValue)
+        let double = Double(sqlColumnValue: sqlColumnValue)
+        
+        //THEN
+        XCTAssertEqual(try XCTUnwrap(int), 1)
+        XCTAssertEqual(try XCTUnwrap(int32), 1)
+        XCTAssertEqual(try XCTUnwrap(int64), 1)
+        XCTAssertEqual(try XCTUnwrap(double), 1)
+    }
 }
 
 private extension SQLConnection {


### PR DESCRIPTION
This PR removes `convert(from:)` from `SQLDataType`, and instead uses a separate protocol (`InitializableBySQLColumnValue`) for such conversions needed by `SQLRow` subscripts.

I also introduced `SQLColumnValue` (a concept previously explored by the name `SQLVariant`) to be used to initialize `InitializableBySQLColumnValue` via a fail-able initializer:

```swift
public protocol InitializableBySQLColumnValue {
    init?(sqlColumnValue: SQLColumnValue)
}
```

Conformances are provided for common types, namely: `Int`, `Int32`, `Int64`, `Double`, `String`, and `Data`. Automatic type conversion is done for those types; that is, if the column is an integer, but it's requested as a string, such conversion is automatically done. This is coherent with SQLite's dynamic type semantics. See this in their [docs](https://www.sqlite.org/c3ref/column_blob.html):

> If the result column is not initially in the requested format (for example, if the query returns an integer but the sqlite3_column_text() interface is used to extract the value) then an automatic type conversion is performed.


All previous tests are passing. I added tests for automatic type conversions.