### PR TITLE
case-insensitive column names for SQLStatement and SQLRow

### DIFF
--- a/Sources/SwiftSQL/SQLStatement.swift
+++ b/Sources/SwiftSQL/SQLStatement.swift
@@ -269,13 +269,16 @@ public final class SQLStatement {
     
     /// Returns the index of a column given its name.
     public func columnIndex(forName name: String) -> Int? {
-        return columnIndices[name]
+        return columnIndices[name.lowercased()]
     }
-    private lazy var columnIndices: [String : Int] = {
+    
+    /// Holds each column index key-ed by its name.
+    /// Initialized for all columns as soon as it's first accessed.
+    public private(set) lazy var columnIndices: [String : Int] = {
         var indices: [String : Int] = [:]
         indices.reserveCapacity(columnCount)
         for index in 0..<columnCount {
-            indices[String(cString: sqlite3_column_name(ref, Int32(index)))] = index
+            indices[columnName(at: index).lowercased()] = index
         }
         return indices
     }()

--- a/Sources/SwiftSQLExt/SwiftSQLExt.swift
+++ b/Sources/SwiftSQLExt/SwiftSQLExt.swift
@@ -59,9 +59,7 @@ public struct SQLRow {
         values = (0..<statement.columnCount).map { index in
             statement.column(at: index)
         }
-        columnIndicesByNames = Dictionary(uniqueKeysWithValues: (0..<statement.columnCount).map { index in
-            (statement.columnName(at: index), index)
-        })
+        columnIndicesByNames = statement.columnIndices
     }
 
     /// Returns a single column of the current result row of a query.
@@ -96,7 +94,7 @@ public struct SQLRow {
     ///
     /// - parameter columnName: The name of the column.
     public subscript<T: InitializableBySQLColumnValue>(columnName: String) -> T {
-        guard let columnIndex = columnIndicesByNames[columnName] else {
+        guard let columnIndex = columnIndicesByNames[columnName.lowercased()] else {
             fatalError("No such column \(columnName)")
         }
         return self[columnIndex]
@@ -109,7 +107,7 @@ public struct SQLRow {
     ///
     /// - parameter columnName: The name of the column.
     public subscript<T: InitializableBySQLColumnValue>(columnName: String) -> T? {
-        guard let columnIndex = columnIndicesByNames[columnName] else {
+        guard let columnIndex = columnIndicesByNames[columnName.lowercased()] else {
             return nil
         }
         return self[columnIndex]

--- a/Tests/SwiftSQLExtTests/SwiftSQLExtTests.swift
+++ b/Tests/SwiftSQLExtTests/SwiftSQLExtTests.swift
@@ -163,6 +163,19 @@ final class SwiftSQLExtTests: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(int64), 1)
         XCTAssertEqual(try XCTUnwrap(double), 1)
     }
+    
+    func testCaseInsensitiveColumnNameSubscripts() throws {
+        // GIVEN
+        try db.populateStore()
+
+        // WHEN
+        let row = try db
+            .prepare("SELECT Name FROM Persons ORDER BY Level ASC")
+            .row()
+
+        // THEN
+        XCTAssertEqual(try XCTUnwrap(row)["name"] as String, "Alice")
+    }
 }
 
 private extension SQLConnection {


### PR DESCRIPTION
Hi, thank you for quickly responding to my PRs. I really appreciate that.

This PR brings back SQLite's case-insensitivity tolerance to the API regarding accessing `SQLStatement`s and `SQLRow`s by column names.

All previous test are passing, and I added one relevant test.

I also removed duplicated code (that retrieved column names in `SQLRow` on init), which resulted in `SQLStatement`'s once private `columnIndices` property becoming public read-only. I'm interested in your thoughts about this part.

Thanks.